### PR TITLE
Fix pageSlug for GTA San Andreas

### DIFF
--- a/src/query_store_data.py
+++ b/src/query_store_data.py
@@ -10,7 +10,9 @@ def get_params_to_query_store_data(cursor, step, include_dlc=False):
     query_str = "{Catalog {searchStore"
     query_str += f'({category_str}start: {cursor}, count: {step}) '
     query_str += "{"
-    query_str += "paging {total} elements {offerMappings {pageSlug} productSlug urlSlug}"
+    query_str += (
+        "paging {total} elements {offerMappings {pageSlug} catalogNs {mappings {pageSlug}} productSlug urlSlug}"
+    )
     query_str += "}}}"
 
     params = {"query": query_str}

--- a/src/slug_utils.py
+++ b/src/slug_utils.py
@@ -11,6 +11,16 @@ def get_offer_slug(store_element):
     return offer_slug
 
 
+def get_namespace_slug(store_element):
+    mappings = store_element.get("catalogNs").get("mappings")
+    if mappings is not None and len(mappings) > 0:
+        namespace_slug = mappings[0]["pageSlug"]
+    else:
+        namespace_slug = None
+
+    return namespace_slug
+
+
 def get_product_slug(store_element):
     product_slug = store_element["productSlug"]
     if product_slug is not None:
@@ -24,11 +34,14 @@ def get_url_slug(store_element):
 
 def to_slug(store_element):
     offer_slug = get_offer_slug(store_element)
+    namespace_slug = get_namespace_slug(store_element)
     product_slug = get_product_slug(store_element)
     url_slug = get_url_slug(store_element)
 
     if offer_slug is not None:
         slug = offer_slug
+    elif namespace_slug is not None:
+        slug = namespace_slug
     elif product_slug is not None:
         slug = product_slug
     else:


### PR DESCRIPTION
There is a typo in the `productSlug` of GTA San Andreas: `definition` instead of `definitive`.

Since the list `offerMappings` is empty, we have to rely on `catalogNs`.

```json
{
  "title": "Grand Theft Auto: San Andreas – The Definitive Edition",
  "offerMappings": [],
  "catalogNs": {
    "mappings": [
      {
        "pageSlug": "grand-theft-auto-san-andreas-the-definitive-edition",
      }
    ]
  },
  "productSlug": "grand-theft-auto-san-andreas-the-definition-edition",
  "urlSlug": "mistymoss-general-audience"
}
```