### PR TITLE
Data: manually remove the sandboxId for the game "war-hospital"

### DIFF
--- a/data/page_mappings.json
+++ b/data/page_mappings.json
@@ -1570,7 +1570,6 @@
     "walking-dead-season-one": "bloodroot",
     "walking-dead-season-two": "buttercup",
     "wanna-survive": "2b4c5960dc284359aede3f131c6e47e0",
-    "war-hospital": "a18f39b19bf0497d8784d5907055a36e",
     "war-mongrels": "7b57136ac766477eb1e687dcd0310da5",
     "warface": "80e804312c2149c69a75aee703e85a9a",
     "warframe": "244aaaa06bfa49d088205b13b9d2d115",


### PR DESCRIPTION
The `sandboxId` of the game "War Hospital" has changed, probably on January 11, 2024 for the release on [EGS](https://epicgames.com/product/war-hospital) and [Steam](https://store.steampowered.com/app/1553000/War_Hospital/).

```diff
- "war-hospital": "a18f39b19bf0497d8784d5907055a36e"
+ "war-hospital": "80bb776135c84a43bb4cdeadc6e541c2"
```

This pull request removes the previous `sandboxId` so that the script can look for the new `sandboxId`.